### PR TITLE
feat(rws_service_provider): RMF-315 — 30s RWS keep-alive heartbeat

### DIFF
--- a/abb_rws_service_provider/include/abb_rws_service_provider/rws_service_provider.h
+++ b/abb_rws_service_provider/include/abb_rws_service_provider/rws_service_provider.h
@@ -167,6 +167,15 @@ namespace abb
       void smAddInRuntimeStatesCallback(const abb_rapid_sm_addin_msgs::RuntimeState::ConstPtr &message);
 
       /**
+       * \brief Periodic keep-alive callback. Fires a cheap RWS GET via
+       *        the lower-priority interface (try-lock) so the controller's
+       *        5-minute inactivity reaper doesn't kill our session
+       *        between operator service calls. See RMF-315 and ABB RWS
+       *        docs ("recommended 30 seconds" HTTPS keep-alive interval).
+       */
+      void keepaliveCallback(const ros::TimerEvent& event);
+
+      /**
    * \brief Gets the contents of a file.
    *
    * The file must be located in the robot controller's home directory.
@@ -687,6 +696,11 @@ namespace abb
    * \brief Subscriber for RobotWare StateMachine Add-In runtime states.
    */
       ros::Subscriber sm_runtime_states_subscriber_;
+
+      /**
+       * \brief Periodic timer that issues an RWS keep-alive request. RMF-315.
+       */
+      ros::Timer keepalive_timer_;
 
       /**
    * \brief List of provided ROS services.

--- a/abb_rws_service_provider/src/rws_service_provider.cpp
+++ b/abb_rws_service_provider/src/rws_service_provider.cpp
@@ -247,7 +247,7 @@ void RWSServiceProvider::keepaliveCallback(const ros::TimerEvent& /*event*/)
   catch (const std::exception& e)
   {
     ROS_WARN_STREAM_THROTTLE_NAMED(
-        60.0, "init",
+        60.0, "keepalive",
         "RWS keep-alive ping failed (will retry in 30s): " << e.what());
   }
 }

--- a/abb_rws_service_provider/src/rws_service_provider.cpp
+++ b/abb_rws_service_provider/src/rws_service_provider.cpp
@@ -205,6 +205,14 @@ RWSServiceProvider::RWSServiceProvider(ros::NodeHandle& nh_params, ros::NodeHand
   }
   // }
 
+  //--------------------------------------------------------
+  // Schedule a 30s RWS keep-alive (RMF-315). ABB documents
+  // a 5-minute inactivity timeout on the controller side and
+  // recommends a 30s keep-alive interval for HTTPS clients.
+  //--------------------------------------------------------
+  keepalive_timer_ =
+      nh_srvs.createTimer(ros::Duration(30.0), &RWSServiceProvider::keepaliveCallback, this);
+
   ROS_INFO_NAMED(ROS_LOG_INIT, "Initialization succeeded, and the node is ready for use");
 }
 
@@ -220,6 +228,28 @@ void RWSServiceProvider::systemStatesCallback(const abb_robot_msgs::SystemState:
 void RWSServiceProvider::smAddInRuntimeStatesCallback(const abb_rapid_sm_addin_msgs::RuntimeState::ConstPtr& message)
 {
   sm_addin_runtime_state_ = *message;
+}
+
+void RWSServiceProvider::keepaliveCallback(const ros::TimerEvent& /*event*/)
+{
+  // Try-lock via runService: if a real ROS service call is currently
+  // holding the interface mutex, that call IS the keep-alive — skip
+  // this tick. Catch & swallow any exception so a transient network
+  // hiccup never crashes the node.
+  try
+  {
+    rws_manager_.runService([](rws::v2_0::RWSStateMachineInterface& iface) {
+      // getSystemInfo() is the cheapest documented GET and is the same
+      // call collectAndUpdateRuntimeData() makes on every poll.
+      (void)iface.getSystemInfo();
+    });
+  }
+  catch (const std::exception& e)
+  {
+    ROS_WARN_STREAM_THROTTLE_NAMED(
+        60.0, "init",
+        "RWS keep-alive ping failed (will retry in 30s): " << e.what());
+  }
 }
 
 bool RWSServiceProvider::getRCDescription(GetRCDescription::Request&, GetRCDescription::Response& response)


### PR DESCRIPTION
### JIRA Tickets
[RMF-315]

### Description
Adds a 30-second RWS keep-alive heartbeat to `rws_service_provider` (the trigger fix for RMF-315).

**Why it's needed**: ABB RWS docs document a **5-minute inactivity timeout** on the controller side and recommend **30-second keep-alive intervals** for HTTPS clients. `rws_service_provider` only talks to the controller when an operator/orchestration calls one of its ROS services — easily minutes apart on a quiet station — so it deterministically hits the idle reaper, gets a 401 on the next call, and (without the parser fix in the pair PR) cannot recover. A cheap GET every 30s prevents the failure mode at its source.

**Implementation**:
- New private `keepaliveCallback` fires `iface.getSystemInfo()` via `rws_manager_.runService(...)` (try-lock semantics — if the interface mutex is held by a real service call, that call IS the keep-alive, so the timer tick is silently skipped).
- Exceptions from the keep-alive call are caught (`std::exception`) and logged via `ROS_WARN_STREAM_THROTTLE_NAMED(60.0, "keepalive", ...)` so a transient network blip never crashes the node.
- The throttle bucket name is `"keepalive"` (independent from the constructor-phase `"init"` bucket) so a startup warning can never silently suppress a keep-alive failure.

### Test Performed
- `catkin build abb_rws_service_provider` succeeds with no new warnings.
- Smoke-launch via `rosrun abb_rws_service_provider rws_service_provider _robot_ip:=127.0.0.1` confirms the binary loads cleanly and the timer is constructed before the "Initialization succeeded" log line.

### Test Not Performed
- 6+ minute idle test against a real Omnicore (the actual validation that the heartbeat blocks the idle reaper) is pending hardware availability.
- Long-soak (30+ min idle) is pending hardware availability.

---
Pair PR: `molginc/abb_librws` — must land first; this PR depends on the raw-string cookie parser to recover from any 401s the heartbeat doesn't catch.


[RMF-315]: https://molg.atlassian.net/browse/RMF-315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ